### PR TITLE
Update cJSON from 1.7.15 to 1.7.18

### DIFF
--- a/src/cjson.c
+++ b/src/cjson.c
@@ -128,7 +128,7 @@ CJSON_PUBLIC(double) cJSON_GetNumberValue(const cJSON * const item)
 }
 
 /* This is a safeguard to prevent copy-pasters from using incompatible C and header files */
-#if (CJSON_VERSION_MAJOR != 1) || (CJSON_VERSION_MINOR != 7) || (CJSON_VERSION_PATCH != 15)
+#if (CJSON_VERSION_MAJOR != 1) || (CJSON_VERSION_MINOR != 7) || (CJSON_VERSION_PATCH != 18)
     #error cJSON.h and cJSON.c have different versions. Make sure that both have the same.
 #endif
 

--- a/src/cjson.h
+++ b/src/cjson.h
@@ -23,8 +23,6 @@
 #ifndef cJSON__h
 #define cJSON__h
 
-#include <stdint.h>
-
 #ifdef __cplusplus
 extern "C"
 {
@@ -116,7 +114,7 @@ typedef struct cJSON
     /* The item's string, if type==cJSON_String  and type == cJSON_Raw */
     char *valuestring;
     /* writing to valueint is DEPRECATED, use cJSON_SetNumberValue instead */
-    int64_t valueint;
+    int valueint;
     /* The item's number, if type==cJSON_Number */
     double valuedouble;
 

--- a/src/cjson.h
+++ b/src/cjson.h
@@ -83,7 +83,7 @@ then using the CJSON_API_VISIBILITY flag to "export" the same symbols the way CJ
 /* project version */
 #define CJSON_VERSION_MAJOR 1
 #define CJSON_VERSION_MINOR 7
-#define CJSON_VERSION_PATCH 15
+#define CJSON_VERSION_PATCH 18
 
 #include <stddef.h>
 


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
  3.19

* Issues fixed (if any):
   Release 3.19 with cJSON update from 1.7.15 to 1.7.18
   
* Brief description of code changes (suitable for use as a commit message):
  cJSON 1.7.15 was released in Aug 25, 2021 and 1.7.18 on May 13, 2024. This is branch to test the update with a stable release.
